### PR TITLE
Windows - Fix problems with spaces in toolpath (ghidra, ida)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
                     "type": "string",
                     "enum": [
                         "ghidra",
-                        "idaPro (experimental Windows Only)"
+                        "idaPro (experimental Windows Only)",
+                        "idaPro 6.6 legacy hexx-plugin (experimental Windows Only)"
                     ],
                     "default": "ghidra",
                     "description": "Select the default decompiler of preference"

--- a/src/extension.js
+++ b/src/extension.js
@@ -27,7 +27,7 @@ function onActivate(context) {
             decompileCtrl.memFs,
             {
                 isCaseSensitive: true,
-                isReadonly: true
+                isReadonly: false
             }
         )
     );

--- a/src/features/decompile.js
+++ b/src/features/decompile.js
@@ -261,14 +261,26 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
                 if (binaryPath.includes('"')) {
                     return reject({ err: "Dangerous filename" }); //binarypath is quoted.
                 }
-
-                Tools._exec(toolpath,
-                    [
-                        '-A', '-B', "-M",
-                        `-o"${projectPath}"`,
-                        `-S"${scriptCmd}"`,
+                let idaArgs = [
+                    '-A', '-B', "-M",
+                    `-o"${projectPath}"`,
+                    `-S"${scriptCmd}"`,
+                    `"${binaryPath}"`
+                ]
+                if(settings.extensionConfig().default.decompiler.selected.includes("idaPro 6.6 legacy hexx-plugin")){
+                    // legacy idaPro Method (ida 6.6 hexx plugin)
+                    // idaw64.exe -A -Ohexx64:-new:output.cpp:ALL "calc.exe"
+                    idaArgs = [
+                        '-A', '-B', '-M',
+                        `Ohexx64:-new:${path.join(projectPath, path.basename(binaryPath)).replace(/\s/g, '_')}.cpp:ALL`,
                         `"${binaryPath}"`
-                    ],
+                    ];
+                    //removeME
+                    vscode.window.showWarningMessage(`DEBUG: idaw64.exe ${idaArgs.join(" ")}`);
+                }
+                
+                Tools._exec(toolpath,
+                    idaArgs,
                     {
                         shell: true, /* dangerous :/ filename may inject stuff? */
                         onClose: (code) => {
@@ -303,12 +315,7 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
                                 //******************************* UGLY COPY PASTA */
 
                                 Tools._exec(toolpathOther,
-                                    [
-                                        '-A', '-B', "-M",
-                                        `-o"${projectPath}"`,
-                                        `-S"${scriptCmd}"`,
-                                        `"${binaryPath}"`
-                                    ],
+                                    idaArgs,
                                     {
                                         shell: true, /* dangerous :/ filename may inject stuff? */
                                         onClose: (code) => {

--- a/src/features/decompile.js
+++ b/src/features/decompile.js
@@ -58,7 +58,7 @@ class Tools {
     static _exec(command, args, options) {
 
         /** windows bugfix #6 - spaces in path */
-        let cwd = undefined;
+        let cwd;
         if(process.platform.startsWith("win")) {
             // node childprocess on windows is
             if(command.includes(" ") && fs.existsSync(command)){
@@ -176,7 +176,7 @@ class Tools {
                                 if (!fs.existsSync(outputFilePath)) {
                                     return reject({ err: "Output file not produced" });
                                 }
-                                const decompiled = `/** 
+                                let decompiled = `/** 
 *  Generator: ${settings.extension().packageJSON.name}@${settings.extension().packageJSON.version} (https://marketplace.visualstudio.com/items?itemName=${settings.extension().packageJSON.publisher}.${settings.extension().packageJSON.name})
 *  Target:    ${binaryPath}
 **/
@@ -266,7 +266,7 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
                     `-o"${projectPath}"`,
                     `-S"${scriptCmd}"`,
                     `"${binaryPath}"`
-                ]
+                ];
                 if(settings.extensionConfig().default.decompiler.selected.includes("idaPro 6.6 legacy hexx-plugin")){
                     // legacy idaPro Method (ida 6.6 hexx plugin)
                     // idaw64.exe -A -Ohexx64:-new:output.cpp:ALL "calc.exe"

--- a/src/features/decompile.js
+++ b/src/features/decompile.js
@@ -299,11 +299,11 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
                                                 }
 
                                                 const decompiled = `/** 
-                *  Generator: ${settings.extension().packageJSON.name}@${settings.extension().packageJSON.version} (https://marketplace.visualstudio.com/items?itemName=${settings.extension().packageJSON.publisher}.${settings.extension().packageJSON.name})
-                *  Target:    ${binaryPath}
-                **/
-                
-                ${fs.readFileSync(outputFilePath, 'utf8')};`;
+*  Generator: ${settings.extension().packageJSON.name}@${settings.extension().packageJSON.version} (https://marketplace.visualstudio.com/items?itemName=${settings.extension().packageJSON.publisher}.${settings.extension().packageJSON.name})
+*  Target:    ${binaryPath}
+**/
+
+${fs.readFileSync(outputFilePath, 'utf8')};`;
 
                                                 ctrl.memFs.writeFile(
                                                     vscode.Uri.parse(`decompileFs:/${path.basename(binaryPath)}.cpp`),


### PR DESCRIPTION
- fixes #6
- disables readonly mode for decompiled files
- fixes mixed line-endings on windows when decompiling with ghidra (empty lines between decompiled codelines)
- adds experimental IDA 6.6 legacy hexx plugin mode
