### PR TITLE
add support for common vscode variables

### DIFF
--- a/src/features/commands/android.js
+++ b/src/features/commands/android.js
@@ -1,9 +1,9 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
- * 
+ *
+ *
  * */
 const path = require('path');
 const tmp = require('tmp');
@@ -16,7 +16,7 @@ class AndroidCmd extends JavaCmd {
     getSupportedFileExtensions(){
         return ['.apk'];
     }
-    
+
     decompile(uri, progressCallback, token, onErrorCallback){
         if (settings.extensionConfig().apk.decompiler.selected == "jd-cli") {
             progressCallback({ message: "unpacking...", increment: 2 });
@@ -31,7 +31,7 @@ class AndroidCmd extends JavaCmd {
 
     dex2jarConvert(binaryPath) {
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.dex2jar.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.dex2jar.path);
             if (!toolpath) {
                 toolpath = path.join(settings.extension().extensionPath, `bundled_tools/dex-tools-2.1-SNAPSHOT/d2j-dex2jar${process.platform.startsWith('win') ? ".bat" : ".sh"}`);
             }
@@ -45,10 +45,10 @@ class AndroidCmd extends JavaCmd {
 
             let outputFilePath = tmp.tmpNameSync(options);
 
-            /** 
-             * 
+            /**
+             *
              * decompile
-             * 
+             *
              * [Dex2Jar._get_command(), '-o', destination, source]
              */
             JavaCmd._exec(toolpath, ["-o", outputFilePath, binaryPath],

--- a/src/features/commands/default.js
+++ b/src/features/commands/default.js
@@ -1,9 +1,9 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
- * 
+ *
+ *
  * */
 const vscode = require('vscode');
 const path = require('path');
@@ -33,7 +33,7 @@ class DefaultCmd extends BaseCommand {
     ghidraDecompile(binaryPath, progressCallback, token, onErrorCallback) {
         let ctrl = this.ctrl;
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.ghidra.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.ghidra.path);
 
             if (!toolpath) {
                 switch (process.platform) {
@@ -104,16 +104,16 @@ class DefaultCmd extends BaseCommand {
                 console.log('Project Directory: ', projectPath);
                 let outputFilePath = tmp.tmpNameSync(options);
 
-                /** 
-                 * 
+                /**
+                 *
                  * decompile
-                 * 
+                 *
                  */
                 let cmd = BaseCommand._exec(toolpath,
                     [projectPath, "vscode-decompiler",
                         "-import", `${binaryPath}`,
                         "-scriptPath", `${path.join(settings.extension().extensionPath, "scripts")}`,
-                        //"-postscript", "ghidra_annotate.py", 
+                        //"-postscript", "ghidra_annotate.py",
                         "-postScript", `${path.join(settings.extension().extensionPath, "scripts", "ghidra_decompile.py")}`, outputFilePath
                     ],
                     {
@@ -122,7 +122,7 @@ class DefaultCmd extends BaseCommand {
                                 if (!fs.existsSync(outputFilePath)) {
                                     return reject({ err: "Output file not produced" });
                                 }
-                                let decompiled = `/** 
+                                let decompiled = `/**
 *  Generator: ${settings.extension().packageJSON.name}@${settings.extension().packageJSON.version} (https://marketplace.visualstudio.com/items?itemName=${settings.extension().packageJSON.publisher}.${settings.extension().packageJSON.name})
 *  Target:    ${binaryPath}
 **/
@@ -175,7 +175,7 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
     idaDecompile(binaryPath, progressCallback, token, onErrorCallback) {
         let ctrl = this.ctrl;
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.idaPro.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.idaPro.path);
 
             if (!toolpath) {
                 vscode.window.showWarningMessage("`IdaPro` is required to decompile binaries. please configure the path to `<ida>/ida[wl].exe` in: code -> preferences -> settings -> `vscode-decompiler.tool.idaPro.path`");
@@ -195,17 +195,17 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
 
                 console.log('Project Directory: ', projectPath);
                 let outputFilePath = path.join(projectPath, `${path.basename(binaryPath, path.extname(binaryPath))}.c`);
-                /** 
-                 * 
+                /**
+                 *
                  * decompile
-                 * 
-                 * 
+                 *
+                 *
                  *  idascript = os.path.abspath(os.path.join(get_download_dir(), "ida_batch_decompile.py"))
                     destination_file = os.path.join(destination, os.path.split(source)[1].rsplit(".", 1)[0] + '.c')
 
                     decompile_script_cmd = '%s -o\\"%s\\"' % (idascript, destination_file)
                     cmd = [Ida32._get_command(), '-B', '-M', '-S"%s"' % decompile_script_cmd, '"' + source + '"']
-                 * 
+                 *
                  */
 
                 //generate idaw candidates:
@@ -261,7 +261,7 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
                                     return reject({ err: "Output file not produced" });
                                 }
 
-                                const decompiled = `/** 
+                                const decompiled = `/**
 *  Generator: ${settings.extension().packageJSON.name}@${settings.extension().packageJSON.version} (https://marketplace.visualstudio.com/items?itemName=${settings.extension().packageJSON.publisher}.${settings.extension().packageJSON.name})
 *  Target:    ${binaryPath}
 **/
@@ -297,7 +297,7 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
                                                     return reject({ err: "Output file not produced" });
                                                 }
 
-                                                const decompiled = `/** 
+                                                const decompiled = `/**
 *  Generator: ${settings.extension().packageJSON.name}@${settings.extension().packageJSON.version} (https://marketplace.visualstudio.com/items?itemName=${settings.extension().packageJSON.publisher}.${settings.extension().packageJSON.name})
 *  Target:    ${binaryPath}
 **/
@@ -350,7 +350,7 @@ ${fs.readFileSync(outputFilePath, 'utf8')};`;
         });
     }
 
-    
+
 }
 
 module.exports = {

--- a/src/features/commands/ethereum.js
+++ b/src/features/commands/ethereum.js
@@ -1,9 +1,9 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
- * 
+ *
+ *
  * */
 const vscode = require('vscode');
 const path = require('path');
@@ -27,7 +27,7 @@ class EthereumEvmCmd extends BaseCommand {
     panoramixDecompile(binaryPath, progressCallback, token) {
         let ctrl = this.ctrl;
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.python38.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.python38.path);
 
             if(!toolpath){
                 return reject({ err: "Python3.8 not found. Please specify the path in `code → preferences → settings: vscode-decompiler.tool.python38.path`" });
@@ -51,8 +51,8 @@ class EthereumEvmCmd extends BaseCommand {
                 if (err) throw err;
 
                 console.log('Project Directory: ', projectPath);
-                /** 
-                 * 
+                /**
+                 *
                  * decompile
                  * cat test.evm | /usr/local/opt/python@3.8/bin/python3.8 panoramix.py stdin --fast --silent
                  */
@@ -136,7 +136,7 @@ class EthereumEvmCmd extends BaseCommand {
 
                 //cmd.stdin.setEncoding('utf-8');
                 cmd.stdin.end(inputData);
-                
+
                 token.onCancellationRequested(() => {
                     cmd.kill("SIGKILL");
                     console.log(`${cmd.pid} - process killed - ${cmd.killed}`);

--- a/src/features/commands/java.js
+++ b/src/features/commands/java.js
@@ -1,9 +1,9 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
- * 
+ *
+ *
  * */
 const path = require('path');
 const tmp = require('tmp');
@@ -27,7 +27,7 @@ class JavaCmd extends BaseCommand {
     jdcliDecompile(binaryPath, progressCallback, token, onErrorCallback) {
         let ctrl = this.ctrl;
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.jdcli.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.jdcli.path);
 
             if (!toolpath) {
                 toolpath = path.join(settings.extension().extensionPath, `bundled_tools/jd-cli-jd-cli-1.2.1/jd-cli${process.platform.startsWith('win') ? ".bat" : ""}`);
@@ -46,10 +46,10 @@ class JavaCmd extends BaseCommand {
 
                 console.log('Project Directory: ', projectPath);
 
-                /** 
-                 * 
+                /**
+                 *
                  * decompile
-                 * 
+                 *
                  * [JdCli._get_command(), '--outputDir', destination, source]
                  */
                 let cmd = BaseCommand._exec(toolpath, ["--outputDir", projectPath, binaryPath],
@@ -99,7 +99,7 @@ class JavaCmd extends BaseCommand {
     jadxDecompile(binaryPath, progressCallback, token, onErrorCallback) {
         let ctrl = this.ctrl;
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.jadx.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.jadx.path);
 
             if (!toolpath) {
                 toolpath = path.join(settings.extension().extensionPath, `bundled_tools/jadx-1.4.2/bin/jadx${process.platform.startsWith('win') ? ".bat" : ""}`);
@@ -118,10 +118,10 @@ class JavaCmd extends BaseCommand {
 
                 console.log('Project Directory: ', projectPath);
 
-                /** 
-                 * 
+                /**
+                 *
                  * decompile
-                 * 
+                 *
                  * [jadx, -d out, input.dex]
                  */
                 let prevs_percent = 0;

--- a/src/features/commands/python.js
+++ b/src/features/commands/python.js
@@ -1,9 +1,9 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
- * 
+ *
+ *
  * */
 const vscode = require('vscode');
 const path = require('path');
@@ -27,7 +27,7 @@ class PythonCmd extends BaseCommand {
     pythonDecompile(binaryPath, progressCallback, token, onErrorCallback) {
         let ctrl = this.ctrl;
         return new Promise((resolve, reject) => {
-            let toolpath = settings.extensionConfig().tool.uncompyle.path;
+            let toolpath = settings.handleConfigOption(settings.extensionConfig().tool.uncompyle.path);
 
             console.log(toolpath);
             tmp.setGracefulCleanup();
@@ -42,10 +42,10 @@ class PythonCmd extends BaseCommand {
 
                 console.log('Project Directory: ', projectPath);
                 let outputFilePath = path.join(projectPath, `${path.basename(binaryPath, path.extname(binaryPath))}${path.extname(binaryPath) == ".pyc" ? ".py" : ".pyo_dis"}`);
-                /** 
-                 * 
+                /**
+                 *
                  * decompile
-                 * 
+                 *
                  * [uncompyle6, -d out, input.pyc/pyo]
                  */
                 let cmd = BaseCommand._exec(toolpath, ["-o", projectPath, binaryPath],

--- a/src/settings.js
+++ b/src/settings.js
@@ -49,8 +49,9 @@ function handleConfigOption(input) {
     }
 
     if (input.includes("${env:")) {
-        for (let env = input.match(/\${env:([^}]+)}/)?.[1]; env; env = input.match(/\${env:([^}]+)}/)?.[1]) {
-            input = input.replaceAll(`\${env:${env}}`, process.env[env] ?? "");
+        let match;
+        while ((match = input.match(/\${env:([^}]+)}/)?.[1])) {
+            input = input.replaceAll(`\${env:${match}}`, process.env[match] ?? "");
         }
     }
     return input;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,12 +1,14 @@
 'use strict';
-/** 
+/**
  * @author github.com/tintinweb
  * @license MIT
- * 
- * 
+ *
+ *
  * */
 /** globals - const */
 const vscode = require('vscode');
+const path = require('path');
+const os = require('os');
 
 function extensionConfig() {
     return vscode.workspace.getConfiguration('vscode-decompiler');
@@ -16,7 +18,46 @@ function extension() {
     return vscode.extensions.getExtension('tintinweb.vscode-decompiler');
 }
 
+/**
+* Replace any references to predefined variables in config string.
+* https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables
+
+* Taken from https://github.com/ziglang/vscode-zig/blob/ff6fc577dbcced13c156d151daf56acca7231ce2/src/zigUtil.ts#L20-L55
+ */
+function handleConfigOption(input) {
+
+    if (!input || typeof input !== "string") {
+        return input;
+    }
+
+    if (input.includes("${userHome}")) {
+        input = input.replaceAll("${userHome}", os.homedir());
+    }
+
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+
+    if (workspaceFolders && workspaceFolders.length > 0) {
+        input = input.replaceAll("${workspaceFolder}", workspaceFolders[workspaceFolders.length - 1].uri.fsPath);
+        input = input.replaceAll("${workspaceFolderBasename}", workspaceFolders[workspaceFolders.length - 1].name);
+    }
+
+
+    input = input.replaceAll("${pathSeparator}", path.sep);
+    input = input.replaceAll("${/}", path.sep);
+    if (input.includes("${cwd}")) {
+        input = input.replaceAll("${cwd}", process.cwd());
+    }
+
+    if (input.includes("${env:")) {
+        for (let env = input.match(/\${env:([^}]+)}/)?.[1]; env; env = input.match(/\${env:([^}]+)}/)?.[1]) {
+            input = input.replaceAll(`\${env:${env}}`, process.env[env] ?? "");
+        }
+    }
+    return input;
+}
+
 module.exports = {
     extensionConfig: extensionConfig,
-    extension: extension
+    extension: extension,
+    handleConfigOption: handleConfigOption
 };


### PR DESCRIPTION
Vscode has a convenient list of [predefined variables](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) that unfortunately don't automatically get recognised the extension authors need to handle them manually.

The actual implementation I mostly just took from the [zig extension](https://github.com/ziglang/vscode-zig/blob/ff6fc577dbcced13c156d151daf56acca7231ce2/src/zigUtil.ts#L20-L55), the way environment variables are detected is admittedly a bit nasty but it should work just fine at least